### PR TITLE
[#018] 알고리즘 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^3.0.2",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.2",
+        "axios": "^1.6.8",
         "mysql2": "^3.9.2",
         "nest-winston": "^1.9.4",
         "reflect-metadata": "^0.2.0",
@@ -1612,6 +1614,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.0.2.tgz",
+      "integrity": "sha512-Z6GuOUdNQjP7FX+OuV2Ybyamse+/e0BFdTWBX5JxpBDKA+YkdLynDgG6HTF04zy6e9zPa19UX0WA2VDoehwhXQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.2.tgz",
@@ -2895,8 +2907,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3605,7 +3626,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3881,7 +3901,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4758,6 +4777,25 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -4827,7 +4865,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7326,6 +7363,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.2",
         "axios": "^1.6.8",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "mysql2": "^3.9.2",
         "nest-winston": "^1.9.4",
         "reflect-metadata": "^0.2.0",
@@ -2307,6 +2309,11 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.9",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
+      "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -3392,6 +3399,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.1.tgz",
+      "integrity": "sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.10.53",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6395,6 +6417,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.59",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.59.tgz",
+      "integrity": "sha512-HeTsOrDF/hWhEiKqZVwg9Cqlep5x2T+IYDENvT2VRj3iX8JQ7Y+omENv+AIn0vC8m6GYhivfCed5Cgfw27r5SA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9119,6 +9146,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",
     "axios": "^1.6.8",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "mysql2": "^3.9.2",
     "nest-winston": "^1.9.4",
     "reflect-metadata": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^3.0.2",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.2",
+    "axios": "^1.6.8",
     "mysql2": "^3.9.2",
     "nest-winston": "^1.9.4",
     "reflect-metadata": "^0.2.0",

--- a/src/Entity/algorithm.ts
+++ b/src/Entity/algorithm.ts
@@ -25,7 +25,13 @@ export class Algorithm {
     bojId: string;
 
     @Column()
-    bojScore: number;
+    rating: number;
+
+    @Column()
+    tier: number;
+
+    @Column()
+    solvedCount: number;
 
     @Column()
     point: number;

--- a/src/algorithm/algorithm.controller.ts
+++ b/src/algorithm/algorithm.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('algorithm')
+export class AlgorithmController {}

--- a/src/algorithm/algorithm.controller.ts
+++ b/src/algorithm/algorithm.controller.ts
@@ -1,4 +1,14 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { AlgorithmService } from './algorithm.service';
+import { CreateAlgorithmDto } from './createAlgorithm.dto';
 
-@Controller('algorithm')
-export class AlgorithmController {}
+@Controller('api/stat/algorithm')
+export class AlgorithmController {
+    constructor(private readonly algorithmService: AlgorithmService) {}
+
+    @Post()
+    async algorithmCreate(@Body() body: CreateAlgorithmDto) {
+        const userId = 'user';
+        await this.algorithmService.createAlgorithm(userId, body.bojId);
+    }
+}

--- a/src/algorithm/algorithm.controller.ts
+++ b/src/algorithm/algorithm.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Param, Patch, Post } from '@nestjs/common';
 import { AlgorithmService } from './algorithm.service';
 import { CreateAlgorithmDto } from './createAlgorithm.dto';
 
@@ -10,5 +10,13 @@ export class AlgorithmController {
     async algorithmCreate(@Body() body: CreateAlgorithmDto) {
         const userId = 'user';
         await this.algorithmService.createAlgorithm(userId, body.bojId);
+    }
+
+    @Patch(':id')
+    async algorithmModify(
+        @Param('id') userId,
+        @Body() body: CreateAlgorithmDto,
+    ) {
+        await this.algorithmService.modifyAlgorithm(userId, body.bojId);
     }
 }

--- a/src/algorithm/algorithm.module.ts
+++ b/src/algorithm/algorithm.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AlgorithmController } from './algorithm.controller';
 import { AlgorithmService } from './algorithm.service';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
+    imports: [HttpModule],
     controllers: [AlgorithmController],
     providers: [AlgorithmService],
 })

--- a/src/algorithm/algorithm.module.ts
+++ b/src/algorithm/algorithm.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { AlgorithmController } from './algorithm.controller';
 import { AlgorithmService } from './algorithm.service';
-import { HttpModule } from '@nestjs/axios';
 
 @Module({
-    imports: [HttpModule],
     controllers: [AlgorithmController],
     providers: [AlgorithmService],
 })

--- a/src/algorithm/algorithm.module.ts
+++ b/src/algorithm/algorithm.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AlgorithmController } from './algorithm.controller';
+import { AlgorithmService } from './algorithm.service';
+
+@Module({
+    controllers: [AlgorithmController],
+    providers: [AlgorithmService],
+})
+export class AlgorithmModule {}

--- a/src/algorithm/algorithm.module.ts
+++ b/src/algorithm/algorithm.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AlgorithmController } from './algorithm.controller';
 import { AlgorithmService } from './algorithm.service';
+import { AlgorithmRepository } from './algorithm.repository';
 
 @Module({
     controllers: [AlgorithmController],
-    providers: [AlgorithmService],
+    providers: [AlgorithmService, AlgorithmRepository],
 })
 export class AlgorithmModule {}

--- a/src/algorithm/algorithm.repository.ts
+++ b/src/algorithm/algorithm.repository.ts
@@ -1,0 +1,11 @@
+import { BaseRepository } from '../utils/base.repository';
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { REQUEST } from '@nestjs/core';
+
+@Injectable({ scope: Scope.REQUEST })
+export class AlgorithmRepository extends BaseRepository {
+    constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
+        super(dataSource, req);
+    }
+}

--- a/src/algorithm/algorithm.repository.ts
+++ b/src/algorithm/algorithm.repository.ts
@@ -16,7 +16,11 @@ export class AlgorithmRepository extends BaseRepository {
         await this.repository.save(algorithm);
     }
 
-    async findOneById(userId) {
+    async findOneById(userId: string) {
         return await this.repository.findOneBy({ userId: userId });
+    }
+
+    async update(userId: string, algorithm: Algorithm) {
+        await this.repository.update({ userId: userId }, algorithm);
     }
 }

--- a/src/algorithm/algorithm.repository.ts
+++ b/src/algorithm/algorithm.repository.ts
@@ -1,11 +1,18 @@
 import { BaseRepository } from '../utils/base.repository';
 import { Inject, Injectable, Scope } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
+import { Algorithm } from '../Entity/algorithm';
 
 @Injectable({ scope: Scope.REQUEST })
 export class AlgorithmRepository extends BaseRepository {
+    private repository: Repository<Algorithm>;
     constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
         super(dataSource, req);
+        this.repository = this.getRepository(Algorithm);
+    }
+
+    async save(algorithm: Algorithm) {
+        await this.repository.save(algorithm);
     }
 }

--- a/src/algorithm/algorithm.repository.ts
+++ b/src/algorithm/algorithm.repository.ts
@@ -15,4 +15,8 @@ export class AlgorithmRepository extends BaseRepository {
     async save(algorithm: Algorithm) {
         await this.repository.save(algorithm);
     }
+
+    async findOneById(userId) {
+        return await this.repository.findOneBy({ userId: userId });
+    }
 }

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -57,7 +57,7 @@ describe('AlgorithmService', () => {
             );
 
             await expect(service.getBOJInfo('qwe')).rejects.toThrow(
-                'BOJ ID Not Found',
+                'incorrect BOJ Id',
             );
         });
     });
@@ -98,7 +98,7 @@ describe('AlgorithmService', () => {
 
             await expect(
                 service.createAlgorithm(userId, bojId),
-            ).rejects.toThrow('BOJ ID Not Found');
+            ).rejects.toThrow('incorrect BOJ Id');
         });
 
         it('중복으로 등록하는 경우', async function () {

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -7,6 +7,8 @@ import { QueryFailedError } from 'typeorm';
 
 const mockAlgorithmRepository = {
     save: jest.fn(),
+    findOneById: jest.fn(),
+    update: jest.fn(),
 };
 
 jest.mock('axios');
@@ -122,6 +124,48 @@ describe('AlgorithmService', () => {
             await expect(
                 service.createAlgorithm(userId, bojId),
             ).rejects.toThrow('이미 등록했습니다.');
+        });
+    });
+
+    describe('modifyAlgorithm', function () {
+        it('should modify algorithm', async function () {
+            const userId = 'user';
+            const bojId = 'user1';
+            const algorithm = new Algorithm();
+            algorithm.userId = userId;
+            algorithm.bojId = 'user2';
+            algorithm.rating = 1500;
+            algorithm.tier = 16;
+            algorithm.solvedCount = 100;
+            algorithm.point = 0;
+            algorithmRepository.findOneById.mockResolvedValue(algorithm);
+
+            const mockResponse = {
+                data: {
+                    rating: 1600,
+                    tier: 17,
+                    solvedCount: 105,
+                },
+            };
+            (axios.get as jest.Mock).mockResolvedValue(mockResponse);
+            await service.modifyAlgorithm(userId, bojId);
+            const callProperty = algorithmRepository.update.mock.calls[0][1];
+            expect(callProperty.bojId).toEqual(bojId);
+            expect(callProperty.rating).toEqual(mockResponse.data.rating);
+            expect(callProperty.tier).toEqual(mockResponse.data.tier);
+            expect(callProperty.solvedCount).toEqual(
+                mockResponse.data.solvedCount,
+            );
+        });
+
+        it('userId 에 해당하는 알고리즘이 없는 경우 에러', async function () {
+            const userId = 'user';
+            const bojId = 'user1';
+            algorithmRepository.findOneById.mockResolvedValue(null);
+
+            await expect(
+                service.modifyAlgorithm(userId, bojId),
+            ).rejects.toThrow('Algorithm info not found');
         });
     });
 });

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AlgorithmService } from './algorithm.service';
+
+describe('AlgorithmService', () => {
+    let service: AlgorithmService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [AlgorithmService],
+        }).compile();
+
+        service = module.get<AlgorithmService>(AlgorithmService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AlgorithmService } from './algorithm.service';
+import axios from 'axios';
 
+jest.mock('axios');
 describe('AlgorithmService', () => {
     let service: AlgorithmService;
 
@@ -14,5 +16,34 @@ describe('AlgorithmService', () => {
 
     it('should be defined', () => {
         expect(service).toBeDefined();
+    });
+
+    describe('getBOJInfo', function () {
+        it('should return boj info', async function () {
+            const mockResponse = {
+                data: {
+                    rating: 1500,
+                    tier: 16,
+                    solvedCount: 100,
+                },
+            };
+            (axios.get as jest.Mock).mockResolvedValue(mockResponse);
+
+            const res = await service.getBOJInfo('userId');
+
+            expect(res.solvedCount).toEqual(100);
+            expect(res.rating).toEqual(1500);
+            expect(res.tier).toEqual(16);
+        });
+
+        it('should throw not found error', async function () {
+            (axios.get as jest.Mock).mockRejectedValue(
+                new Error('Failed to fetch'),
+            );
+
+            await expect(service.getBOJInfo('qwe')).rejects.toThrow(
+                'BOJ ID Not Found',
+            );
+        });
     });
 });

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -168,4 +168,34 @@ describe('AlgorithmService', () => {
             ).rejects.toThrow('Algorithm info not found');
         });
     });
+
+    describe('updateAlgorithm', function () {
+        it('should update', async function () {
+            const userId = 'user';
+            const algorithm = new Algorithm();
+            algorithm.userId = userId;
+            algorithm.bojId = 'user1';
+            algorithm.rating = 1500;
+            algorithm.tier = 16;
+            algorithm.solvedCount = 100;
+            algorithm.point = 0;
+            algorithmRepository.findOneById.mockResolvedValue(algorithm);
+
+            const mockResponse = {
+                data: {
+                    rating: 1600,
+                    tier: 17,
+                    solvedCount: 105,
+                },
+            };
+            (axios.get as jest.Mock).mockResolvedValue(mockResponse);
+            await service.updateAlgorithm(userId);
+            const callProperty = algorithmRepository.update.mock.calls[0][1];
+            expect(callProperty.rating).toEqual(mockResponse.data.rating);
+            expect(callProperty.tier).toEqual(mockResponse.data.tier);
+            expect(callProperty.solvedCount).toEqual(
+                mockResponse.data.solvedCount,
+            );
+        });
+    });
 });

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AlgorithmService {}

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+    BadRequestException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
 import axios from 'axios';
 import { AlgorithmRepository } from './algorithm.repository';
 import { Algorithm } from '../Entity/algorithm';
@@ -54,7 +58,7 @@ export class AlgorithmService {
     async modifyAlgorithm(userId: string, bojId: string) {
         const algorithm = await this.algorithmRepository.findOneById(userId);
         if (algorithm === null) {
-            throw new NotFoundError('Algorithm info not found');
+            throw new NotFoundException('Algorithm info not found');
         }
         const bojInfo = await this.getBOJInfo(bojId);
         algorithm.bojId = bojId;

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -46,7 +46,7 @@ export class AlgorithmService {
                 solvedCount: bojInfo.solvedCount,
             };
         } catch (e) {
-            throw new Error('BOJ ID Not Found');
+            throw new BadRequestException('incorrect BOJ Id');
         }
     }
 

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -1,4 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import axios from 'axios';
 
+const URL = 'https://solved.ac/api/v3/user/show?handle=';
 @Injectable()
-export class AlgorithmService {}
+export class AlgorithmService {
+    async getBOJInfo(boj_id: string) {
+        try {
+            const res = await axios.get(URL + boj_id);
+            const boj_info = res.data;
+            return {
+                rating: boj_info.rating,
+                tier: boj_info.tier,
+                solvedCount: boj_info.solvedCount,
+            };
+        } catch (e) {
+            throw new Error('BOJ ID Not Found');
+        }
+    }
+}

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -51,6 +51,20 @@ export class AlgorithmService {
         await this.algorithmRepository.update(userId, algorithm);
     }
 
+    async modifyAlgorithm(userId: string, bojId: string) {
+        const algorithm = await this.algorithmRepository.findOneById(userId);
+        if (algorithm === null) {
+            throw new NotFoundError('Algorithm info not found');
+        }
+        const bojInfo = await this.getBOJInfo(bojId);
+        algorithm.bojId = bojId;
+        algorithm.tier = bojInfo.tier;
+        algorithm.rating = bojInfo.rating;
+        algorithm.solvedCount = bojInfo.solvedCount;
+        algorithm.point = this.calculatePoint(bojInfo);
+        await this.algorithmRepository.update(userId, algorithm);
+    }
+
     async getBOJInfo(bojId: string) {
         try {
             const res = await axios.get(URL + bojId);

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
+import { AlgorithmRepository } from './algorithm.repository';
+import { Algorithm } from '../Entity/algorithm';
 
 const URL = 'https://solved.ac/api/v3/user/show?handle=';
 
@@ -10,14 +12,26 @@ export interface BOJInfo {
 }
 @Injectable()
 export class AlgorithmService {
-    async getBOJInfo(boj_id: string) {
+    constructor(private algorithmRepository: AlgorithmRepository) {}
+    async createAlgorithm(userId: string, bojId: string) {
+        const bojInfo = await this.getBOJInfo(bojId);
+        const algorithm: Algorithm = new Algorithm();
+        algorithm.userId = userId;
+        algorithm.bojId = bojId;
+        algorithm.rating = bojInfo.rating;
+        algorithm.tier = bojInfo.tier;
+        algorithm.solvedCount = bojInfo.solvedCount;
+        algorithm.point = this.calculatePoint(bojInfo);
+        await this.algorithmRepository.save(algorithm);
+    }
+    async getBOJInfo(bojId: string) {
         try {
-            const res = await axios.get(URL + boj_id);
-            const boj_info = res.data;
+            const res = await axios.get(URL + bojId);
+            const bojInfo = res.data;
             return {
-                rating: boj_info.rating,
-                tier: boj_info.tier,
-                solvedCount: boj_info.solvedCount,
+                rating: bojInfo.rating,
+                tier: bojInfo.tier,
+                solvedCount: bojInfo.solvedCount,
             };
         } catch (e) {
             throw new Error('BOJ ID Not Found');

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { AlgorithmRepository } from './algorithm.repository';
 import { Algorithm } from '../Entity/algorithm';
 import { QueryFailedError } from 'typeorm';
+import { NotFoundError } from 'rxjs';
 
 const URL = 'https://solved.ac/api/v3/user/show?handle=';
 
@@ -36,6 +37,20 @@ export class AlgorithmService {
             }
         }
     }
+
+    async updateAlgorithm(userId: string) {
+        const algorithm = await this.algorithmRepository.findOneById(userId);
+        if (algorithm === null) {
+            throw new NotFoundError('Algorithm info not found');
+        }
+        const bojInfo = await this.getBOJInfo(algorithm.bojId);
+        algorithm.tier = bojInfo.tier;
+        algorithm.rating = bojInfo.rating;
+        algorithm.solvedCount = bojInfo.solvedCount;
+        algorithm.point = this.calculatePoint(bojInfo);
+        await this.algorithmRepository.update(userId, algorithm);
+    }
+
     async getBOJInfo(bojId: string) {
         try {
             const res = await axios.get(URL + bojId);

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -2,6 +2,12 @@ import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 
 const URL = 'https://solved.ac/api/v3/user/show?handle=';
+
+export interface BOJInfo {
+    tier: number;
+    solvedCount: number;
+    rating: number;
+}
 @Injectable()
 export class AlgorithmService {
     async getBOJInfo(boj_id: string) {
@@ -16,5 +22,9 @@ export class AlgorithmService {
         } catch (e) {
             throw new Error('BOJ ID Not Found');
         }
+    }
+
+    private calculatePoint(bojInfo: BOJInfo) {
+        return 0;
     }
 }

--- a/src/algorithm/createAlgorithm.dto.ts
+++ b/src/algorithm/createAlgorithm.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateAlgorithmDto {
+    @IsString()
+    @IsNotEmpty()
+    bojId: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TypeOrmConfigService } from './Config/typeorm.config';
 import { ConfigModule } from '@nestjs/config';
+import { AlgorithmModule } from './algorithm/algorithm.module';
 import * as process from 'process';
 
 @Module({
@@ -15,6 +16,7 @@ import * as process from 'process';
             isGlobal: true,
             envFilePath: `${process.cwd()}/envs/${process.env.NODE_ENV}.env`,
         }),
+        AlgorithmModule,
     ],
     controllers: [AppController],
     providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { winstonLogger } from './Config/winston.config';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule, {
         logger: winstonLogger,
     });
+    app.useGlobalPipes(new ValidationPipe());
     await app.listen(3000);
 }
 bootstrap();

--- a/src/utils/base.repository.ts
+++ b/src/utils/base.repository.ts
@@ -1,0 +1,14 @@
+import { DataSource, EntityManager, Repository } from 'typeorm';
+
+export class BaseRepository {
+    constructor(
+        private dataSource: DataSource,
+        private request: Request,
+    ) {}
+
+    getRepository<T>(entityCls: new () => T): Repository<T> {
+        const entityManager: EntityManager =
+            this.request['ENTITY_MANAGER'] ?? this.dataSource.manager;
+        return entityManager.getRepository(entityCls);
+    }
+}


### PR DESCRIPTION
## 이슈
- #18

## 체크리스트
- [x] 백준 아이디 수정 기능 추가
- [x] 백준 정보를 업데이트 하는 기능 추가

## 고민한 내용
- 유저가 본인의 백준아이디를 변경하는 메서드는 modify
- 유저의 백준 정보를 갱신하는 메서드는 update 
- 서비스에서 커스텀 에러를 발생시키는 것이 나을 수도 있다는 고민을 함. 서비스에서 나온 에러가 응답으로 돌아가지 않고 다르게 사용될 수도있을 듯. 필터를 사용해서 서비스의 에러를 변형시키는 것도 괞찮을것 같기도 함.