### PR TITLE
[#022] 알고리즘 삭제

### DIFF
--- a/src/algorithm/algorithm.controller.ts
+++ b/src/algorithm/algorithm.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post } from '@nestjs/common';
 import { AlgorithmService } from './algorithm.service';
 import { CreateAlgorithmDto } from './createAlgorithm.dto';
 
@@ -18,5 +18,10 @@ export class AlgorithmController {
         @Body() body: CreateAlgorithmDto,
     ) {
         await this.algorithmService.modifyAlgorithm(userId, body.bojId);
+    }
+
+    @Delete(':id')
+    async algorithmRemove(@Param('id') userId) {
+        await this.algorithmService.removeAlgorithm(userId);
     }
 }

--- a/src/algorithm/algorithm.repository.ts
+++ b/src/algorithm/algorithm.repository.ts
@@ -23,4 +23,8 @@ export class AlgorithmRepository extends BaseRepository {
     async update(userId: string, algorithm: Algorithm) {
         await this.repository.update({ userId: userId }, algorithm);
     }
+
+    async delete(userId: string) {
+        await this.repository.delete({ userId: userId });
+    }
 }

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -53,10 +53,10 @@ describe('AlgorithmService', () => {
             expect(res.tier).toEqual(16);
         });
 
-        it('should throw not found error', async function () {
-            (axios.get as jest.Mock).mockRejectedValue(
-                new Error('Failed to fetch'),
-            );
+        it('should throw not found error when bojId is incorrect', async function () {
+            (axios.get as jest.Mock).mockRejectedValue({
+                response: { status: 404 },
+            });
 
             await expect(service.getBOJInfo('qwe')).rejects.toThrow(
                 'incorrect BOJ Id',
@@ -92,9 +92,9 @@ describe('AlgorithmService', () => {
         });
 
         it('백준 아이디가 없는 경우', async function () {
-            (axios.get as jest.Mock).mockRejectedValue(
-                new Error('Failed to fetch'),
-            );
+            (axios.get as jest.Mock).mockRejectedValue({
+                response: { status: 404 },
+            });
             const userId = 'user';
             const bojId = 'user';
 

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -114,13 +114,7 @@ describe('AlgorithmService', () => {
             (axios.get as jest.Mock).mockResolvedValue(mockResponse);
             const userId = 'user';
             const bojId = 'user';
-            algorithmRepository.save.mockRejectedValue(
-                new QueryFailedError(
-                    'insert',
-                    [],
-                    new Error('Duplicate entry error'),
-                ),
-            );
+            algorithmRepository.findOneById.mockResolvedValue(new Algorithm());
             await expect(
                 service.createAlgorithm(userId, bojId),
             ).rejects.toThrow('이미 등록했습니다.');

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -3,12 +3,12 @@ import { AlgorithmService } from './algorithm.service';
 import axios from 'axios';
 import { AlgorithmRepository } from './algorithm.repository';
 import { Algorithm } from '../Entity/algorithm';
-import { QueryFailedError } from 'typeorm';
 
 const mockAlgorithmRepository = {
     save: jest.fn(),
     findOneById: jest.fn(),
     update: jest.fn(),
+    delete: jest.fn(),
 };
 
 jest.mock('axios');
@@ -189,6 +189,25 @@ describe('AlgorithmService', () => {
             expect(callProperty.tier).toEqual(mockResponse.data.tier);
             expect(callProperty.solvedCount).toEqual(
                 mockResponse.data.solvedCount,
+            );
+        });
+    });
+
+    describe('removeAlgorithm', function () {
+        it('should remove', async function () {
+            const userId = 'user';
+            algorithmRepository.findOneById.mockResolvedValue(new Algorithm());
+
+            await service.removeAlgorithm(userId);
+
+            expect(algorithmRepository.delete).toHaveBeenCalled();
+        });
+
+        it('존재하지 않는 것을 지우려고 할 때 오류 발생', async function () {
+            const userId = 'user';
+            algorithmRepository.findOneById.mockResolvedValue(null);
+            await expect(service.removeAlgorithm(userId)).rejects.toThrow(
+                'algorithm not found',
             );
         });
     });

--- a/src/algorithm/algorithm.service.spec.ts
+++ b/src/algorithm/algorithm.service.spec.ts
@@ -16,7 +16,7 @@ describe('AlgorithmService', () => {
     let service: AlgorithmService;
     let algorithmRepository;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 AlgorithmService,
@@ -190,6 +190,17 @@ describe('AlgorithmService', () => {
             expect(callProperty.solvedCount).toEqual(
                 mockResponse.data.solvedCount,
             );
+        });
+
+        it('백준 아이디가 solved.ac에서 삭제된 경우 스탯 초기화', async function () {
+            const userId = 'user';
+            algorithmRepository.findOneById.mockResolvedValue(new Algorithm());
+            (axios.get as jest.Mock).mockRejectedValue({
+                response: { status: 404 },
+            });
+            await service.updateAlgorithm(userId);
+
+            expect(algorithmRepository.delete).toHaveBeenCalled();
         });
     });
 

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -81,7 +81,11 @@ export class AlgorithmService {
                 solvedCount: bojInfo.solvedCount,
             };
         } catch (e) {
-            throw new BadRequestException('incorrect BOJ Id');
+            if (e.response && e.response.status === 404) {
+                throw new BadRequestException('incorrect BOJ Id');
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -63,6 +63,14 @@ export class AlgorithmService {
         await this.algorithmRepository.update(userId, algorithm);
     }
 
+    async removeAlgorithm(userId: string) {
+        const isExist = await this.algorithmRepository.findOneById(userId);
+        if (!isExist) {
+            throw new NotFoundException('algorithm not found');
+        }
+        await this.algorithmRepository.delete(userId);
+    }
+
     async getBOJInfo(bojId: string) {
         try {
             const res = await axios.get(URL + bojId);


### PR DESCRIPTION
## 이슈
- #22

## 체크리스트
- [x] 알고리즘 정보 삭제 기능 구현
- [x] 알고리즘 생성시 존재하는지 확인
- [x] 백준 정보를 가져올 때 404 에러의 경우만 처리 하도록 수정 

## 고민한 내용
### 백준 정보를 가져오는 부분
 - 기존에는 axios를 요청할 때 에러가 나면 어떤 에러든 BadRequest를 던지도록 구현했다.
 - 하지만 모든 에러를 클라이언트의 탓으로 돌리기는 어렵다고 판단했다. 예를 들어 네트워크가 안되거나 solved.ac 사이트가 점검중이라 응답이 어려운경우에도 클라이언트의 오류라고 응답이 갈 수 있기 때문이다.
 - 따라서 404 응답이 온경우, 즉 solved.ac 에서 명확하게 없는 자원이라는 응답이 온경우에만 클라이언트의 오류로 응답하도록 하였다.

### soft-delete vs hard delete
- 현재로서는 구현의 간편함을 위해 hard delete를 사용하기로 했다.
- 개발 시간이 충분하게 주어지지 않아서 soft delete를 구현하기에는 무리가 있다고 판단했다.