### PR TITLE
[#043] User 삭제 구현

### DIFF
--- a/src/Entity/algorithm.ts
+++ b/src/Entity/algorithm.ts
@@ -36,7 +36,7 @@ export class Algorithm {
     @Column()
     point: number;
 
-    @OneToOne(() => User, (user) => user.userId)
+    @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
 }

--- a/src/Entity/github.ts
+++ b/src/Entity/github.ts
@@ -27,7 +27,7 @@ export class Github {
     @Column()
     accessToken: string;
 
-    @OneToOne(() => User, (user) => user.userId)
+    @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
 }

--- a/src/Entity/grade.ts
+++ b/src/Entity/grade.ts
@@ -24,7 +24,7 @@ export class Grade {
     @Column()
     point: number;
 
-    @OneToOne(() => User, (user) => user.userId)
+    @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
 }

--- a/src/Entity/totalPoint.ts
+++ b/src/Entity/totalPoint.ts
@@ -21,7 +21,7 @@ export class TotalPoint {
     @Column()
     point: number;
 
-    @OneToOne(() => User, (user) => user.userId)
+    @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
 }

--- a/src/Entity/user.ts
+++ b/src/Entity/user.ts
@@ -68,18 +68,18 @@ export class User {
     @DeleteDateColumn()
     deleteDate: Date;
 
-    @OneToOne(() => Github, (github) => github.userId, { cascade: ['remove'] })
+    @OneToOne(() => Github, (github) => github.user, { cascade: ['remove'] })
     github: Github;
 
-    @OneToOne(() => Algorithm, (algorithm) => algorithm.userId, {
+    @OneToOne(() => Algorithm, (algorithm) => algorithm.user, {
         cascade: ['remove'],
     })
     algorithm: Algorithm;
 
-    @OneToOne(() => Grade, (grade) => grade.userId, { cascade: ['remove'] })
+    @OneToOne(() => Grade, (grade) => grade.user, { cascade: ['remove'] })
     grade: Grade;
 
-    @OneToOne(() => TotalPoint, (totalPoint) => totalPoint.userId, {
+    @OneToOne(() => TotalPoint, (totalPoint) => totalPoint.user, {
         cascade: ['remove'],
     })
     totalScore: TotalPoint;

--- a/src/Entity/user.ts
+++ b/src/Entity/user.ts
@@ -68,15 +68,19 @@ export class User {
     @DeleteDateColumn()
     deleteDate: Date;
 
-    @OneToOne(() => Github, (github) => github.userId)
+    @OneToOne(() => Github, (github) => github.userId, { cascade: ['remove'] })
     github: Github;
 
-    @OneToOne(() => Algorithm, (algorithm) => algorithm.userId)
+    @OneToOne(() => Algorithm, (algorithm) => algorithm.userId, {
+        cascade: ['remove'],
+    })
     algorithm: Algorithm;
 
-    @OneToOne(() => Grade, (grade) => grade.userId)
+    @OneToOne(() => Grade, (grade) => grade.userId, { cascade: ['remove'] })
     grade: Grade;
 
-    @OneToOne(() => TotalPoint, (totalPoint) => totalPoint.userId)
+    @OneToOne(() => TotalPoint, (totalPoint) => totalPoint.userId, {
+        cascade: ['remove'],
+    })
     totalScore: TotalPoint;
 }

--- a/src/Entity/user.ts
+++ b/src/Entity/user.ts
@@ -65,9 +65,6 @@ export class User {
     })
     updateDate: Date;
 
-    @DeleteDateColumn()
-    deleteDate: Date;
-
     @OneToOne(() => Github, (github) => github.user, { cascade: ['remove'] })
     github: Github;
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,10 +7,14 @@ export class AuthController {
     constructor(private authService: AuthService) {}
     @Post('apple')
     async signInWithApple(@Body() body: AppleLoginDto) {
-        const providerId = await this.authService.validateAppleOAuth(body);
-        if (!providerId) {
+        try {
+            const providerId = await this.authService.validateAppleOAuth(body);
+            if (!providerId) {
+                throw new UnauthorizedException('토큰이 유효하지 않음');
+            }
+            return await this.authService.logInOrSignUp(providerId);
+        } catch (e) {
             throw new UnauthorizedException('토큰이 유효하지 않음');
         }
-        return await this.authService.logInOrSignUp(providerId);
     }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Param, Put, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Param,
+    Put,
+    UseGuards,
+} from '@nestjs/common';
 import { UpdateUserInfoDto } from './dto/update-user-info.dto';
 import { UserService } from './user.service';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
@@ -16,5 +23,11 @@ export class UserController {
         @Param('id') userId: string,
     ) {
         await this.userService.updateUserInfo(userId, body);
+    }
+
+    @UseGuards(OwnershipGuard)
+    @Delete(':id')
+    async userRemove(@Param('id') userId: string) {
+        await this.userService.removeUser(userId);
     }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -20,6 +20,13 @@ export class UserRepository extends BaseRepository {
         return await this.repository.findOneBy({ userId: userId });
     }
 
+    async findOneWithStats(userId: string) {
+        return await this.repository.findOne({
+            where: { userId: userId },
+            relations: ['github', 'algorithm', 'grade', 'totalScore'],
+        });
+    }
+
     async save(user: User) {
         return await this.repository.save(user);
     }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -27,4 +27,12 @@ export class UserRepository extends BaseRepository {
     async update(userId: string, user: User) {
         return await this.repository.update({ userId: userId }, user);
     }
+
+    async delete(userId: string) {
+        const user = await this.repository.findOne({
+            where: { userId: userId },
+            relations: ['github', 'algorithm', 'grade', 'totalScore'],
+        });
+        await this.repository.remove(user);
+    }
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -28,11 +28,7 @@ export class UserRepository extends BaseRepository {
         return await this.repository.update({ userId: userId }, user);
     }
 
-    async delete(userId: string) {
-        const user = await this.repository.findOne({
-            where: { userId: userId },
-            relations: ['github', 'algorithm', 'grade', 'totalScore'],
-        });
+    async delete(user: User) {
         await this.repository.remove(user);
     }
 }

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -10,6 +10,8 @@ const mockUserRepository = {
     save: jest.fn(),
     findOneByUserId: jest.fn(),
     update: jest.fn(),
+    findOneWithStats: jest.fn(),
+    delete: jest.fn(),
 };
 
 describe('UserService', () => {
@@ -152,6 +154,26 @@ describe('UserService', () => {
             expect(callProperty.nickname).toEqual('nickname');
             expect(callProperty.major).toEqual('major');
             expect(callProperty.name).toEqual('name');
+        });
+    });
+
+    describe('removeUser', function () {
+        it('should delete user', async function () {
+            const userId = 'user';
+            const user = new User();
+            mockUserRepository.findOneWithStats.mockResolvedValue(user);
+
+            await service.removeUser(userId);
+
+            expect(mockUserRepository.delete).toHaveBeenCalledWith(user);
+        });
+
+        it('should throw Not Found Error', function () {
+            const userId = 'user';
+            mockUserRepository.findOneWithStats.mockResolvedValue(null);
+            expect(service.removeUser(userId)).rejects.toThrow(
+                'User Not Found',
+            );
         });
     });
 });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -62,10 +62,7 @@ export class UserService {
     }
 
     async removeUser(userId: string) {
-        const user = await this.userRepository.getRepository(User).findOne({
-            where: { userId: userId },
-            relations: ['github', 'algorithm', 'grade', 'totalScore'],
-        });
+        const user = await this.userRepository.findOneWithStats(userId);
         if (!user) {
             throw new NotFoundException('User Not Found');
         }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -61,6 +61,17 @@ export class UserService {
         user.birthDate = userInfoToUpdate.birthDate;
     }
 
+    async removeUser(userId: string) {
+        const user = await this.userRepository.getRepository(User).findOne({
+            where: { userId: userId },
+            relations: ['github', 'algorithm', 'grade', 'totalScore'],
+        });
+        if (!user) {
+            throw new NotFoundException('User Not Found');
+        }
+        await this.userRepository.delete(user);
+    }
+
     generateUserId() {
         const uuid: string = uuidv4();
         return uuid.slice(0, 8);


### PR DESCRIPTION
## 이슈
- #43 

## 체크리스트
- [x] 사용자 삭제하는 기능 구현
- [x] 사용자가 삭제되면 연관된 기능도 같이 삭제

## 고민한 내용
### Cascase
- 사용자를 삭제 한다는 것은 회원탈퇴를 한다는 것이다.
- 때문에 사용자와 연관된 데이터 깃허브, 알고리즘, 학점 을 삭제해주어야 했다.
- typeORM의 cascase 옵션을 사용해서 삭제 하였다.
