### PR TITLE
[#051] 스탯 조회 구현

### DIFF
--- a/src/Config/typeorm.config.ts
+++ b/src/Config/typeorm.config.ts
@@ -21,7 +21,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
             password: this.configService.get('DB_PASSWORD'),
             database: this.configService.get('DB_DATABASE'),
             entities: [User, Algorithm, Github, Grade, TotalPoint],
-            synchronize: process.env.NODE_ENV !== 'prod',
+            synchronize: true,
             namingStrategy: new SnakeNamingStrategy(),
         };
     }

--- a/src/algorithm/algorithm.module.ts
+++ b/src/algorithm/algorithm.module.ts
@@ -6,5 +6,6 @@ import { AlgorithmRepository } from './algorithm.repository';
 @Module({
     controllers: [AlgorithmController],
     providers: [AlgorithmService, AlgorithmRepository],
+    exports: [AlgorithmService],
 })
 export class AlgorithmModule {}

--- a/src/algorithm/algorithm.service.ts
+++ b/src/algorithm/algorithm.service.ts
@@ -20,6 +20,9 @@ export interface BOJInfo {
 export class AlgorithmService {
     private logger = new Logger(AlgorithmService.name);
     constructor(private algorithmRepository: AlgorithmRepository) {}
+    async findAlgorithm(userId: string) {
+        return await this.algorithmRepository.findOneById(userId);
+    }
     async createAlgorithm(userId: string, bojId: string) {
         const bojInfo = await this.getBOJInfo(bojId);
         const isExist = await this.algorithmRepository.findOneById(userId);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { GithubModule } from './github/github.module';
 import { GradeController } from './grade/grade.controller';
 import { GradeService } from './grade/grade.service';
 import { GradeModule } from './grade/grade.module';
+import { RankModule } from './rank/rank.module';
 import * as process from 'process';
 
 @Module({
@@ -27,6 +28,7 @@ import * as process from 'process';
         UserModule,
         GithubModule,
         GradeModule,
+        RankModule,
     ],
     controllers: [AppController],
     providers: [AppService],

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { GithubService } from './github.service';
 import { GithubController } from './github.controller';
 import { GithubRepository } from './github.repository';
+import { GradeService } from '../grade/grade.service';
 
 @Module({
     providers: [GithubService, GithubRepository],
     controllers: [GithubController],
+    exports: [GithubService],
 })
 export class GithubModule {}

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import {
+    BadRequestException,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GithubRepository } from './github.repository';
 import { Github } from '../Entity/github';
@@ -11,6 +16,10 @@ export class GithubService {
         private configService: ConfigService,
         private githubRepository: GithubRepository,
     ) {}
+
+    async findGithub(userId: string) {
+        return await this.githubRepository.findOne(userId);
+    }
 
     public async createGithub(tokens: CreateGithubDto, userId: string) {
         const userResource = await this.getUserResource(tokens.accessToken);

--- a/src/grade/grade.module.ts
+++ b/src/grade/grade.module.ts
@@ -6,5 +6,6 @@ import { GradeController } from './grade.controller';
 @Module({
     providers: [GradeService, GradeRepository],
     controllers: [GradeController],
+    exports: [GradeService],
 })
 export class GradeModule {}

--- a/src/grade/grade.service.ts
+++ b/src/grade/grade.service.ts
@@ -9,6 +9,11 @@ import { Grade } from '../Entity/grade';
 @Injectable()
 export class GradeService {
     constructor(private gradeRepository: GradeRepository) {}
+
+    async findGrade(userId: string) {
+        return await this.gradeRepository.findOne(userId);
+    }
+
     public async gradeCreate(userId: string, grade: number) {
         const isExist = await this.gradeRepository.findOne(userId);
 

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('rank')
+export class RankController {}

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,4 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { StatFindDto } from './stat-find.dto';
+import { RankService } from './rank.service';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 
-@Controller('rank')
-export class RankController {}
+@UseGuards(JwtAuthGuard)
+@Controller('api')
+export class RankController {
+    constructor(private rankService: RankService) {}
+
+    @Get('stat/:id')
+    async statFind(@Param('id') userId: string): Promise<StatFindDto> {
+        return await this.rankService.findStat(userId);
+    }
+}

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RankController } from './rank.controller';
+import { RankService } from './rank.service';
+
+@Module({
+  controllers: [RankController],
+  providers: [RankService]
+})
+export class RankModule {}

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { RankController } from './rank.controller';
 import { RankService } from './rank.service';
+import { GithubModule } from '../github/github.module';
+import { AlgorithmModule } from '../algorithm/algorithm.module';
+import { GradeModule } from '../grade/grade.module';
 
 @Module({
-  controllers: [RankController],
-  providers: [RankService]
+    imports: [GithubModule, AlgorithmModule, GradeModule],
+    controllers: [RankController],
+    providers: [RankService],
 })
 export class RankModule {}

--- a/src/rank/rank.service.spec.ts
+++ b/src/rank/rank.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RankService } from './rank.service';
+
+describe('RankService', () => {
+  let service: RankService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RankService],
+    }).compile();
+
+    service = module.get<RankService>(RankService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/rank/rank.service.spec.ts
+++ b/src/rank/rank.service.spec.ts
@@ -1,18 +1,89 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RankService } from './rank.service';
+import { GithubService } from '../github/github.service';
+import { AlgorithmService } from '../algorithm/algorithm.service';
+import { GradeService } from '../grade/grade.service';
+import { Github } from '../Entity/github';
+import { Algorithm } from '../Entity/algorithm';
+import { Grade } from '../Entity/grade';
+
+const mockGitService = {
+    findGithub: jest.fn(),
+};
+
+const mockGradeService = {
+    findGrade: jest.fn(),
+};
+
+const mockAlgorithmService = {
+    findAlgorithm: jest.fn(),
+};
 
 describe('RankService', () => {
-  let service: RankService;
+    let service: RankService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [RankService],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                RankService,
+                {
+                    provide: GithubService,
+                    useValue: mockGitService,
+                },
+                {
+                    provide: GradeService,
+                    useValue: mockGradeService,
+                },
+                {
+                    provide: AlgorithmService,
+                    useValue: mockAlgorithmService,
+                },
+            ],
+        }).compile();
 
-    service = module.get<RankService>(RankService);
-  });
+        service = module.get<RankService>(RankService);
+    });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+
+    describe('findStat', function () {
+        it('should return stat', async function () {
+            const userId = 'qwe';
+            const github = new Github();
+            const algorithm = new Algorithm();
+            const grade = new Grade();
+            github.point = 123;
+            algorithm.point = 123;
+            grade.grade = 123;
+
+            mockGitService.findGithub.mockResolvedValue(github);
+            mockAlgorithmService.findAlgorithm.mockResolvedValue(algorithm);
+            mockGradeService.findGrade.mockResolvedValue(grade);
+
+            const result = await service.findStat(userId);
+            expect(result.grade).toEqual(grade.grade);
+            expect(result.githubPoint).toEqual(github.point);
+            expect(result.algorithmPoint).toEqual(algorithm.point);
+        });
+
+        it('should return null if stat does not exist', async function () {
+            const userId = 'qwe';
+            const github = new Github();
+            const algorithm = null;
+            const grade = new Grade();
+            github.point = 123;
+            grade.grade = 123;
+
+            mockGitService.findGithub.mockResolvedValue(github);
+            mockAlgorithmService.findAlgorithm.mockResolvedValue(algorithm);
+            mockGradeService.findGrade.mockResolvedValue(grade);
+
+            const result = await service.findStat(userId);
+            expect(result.grade).toEqual(grade.grade);
+            expect(result.githubPoint).toEqual(github.point);
+            expect(result.algorithmPoint).toEqual(null);
+        });
+    });
 });

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RankService {}

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,4 +1,25 @@
 import { Injectable } from '@nestjs/common';
+import { GithubService } from '../github/github.service';
+import { AlgorithmService } from '../algorithm/algorithm.service';
+import { GradeService } from '../grade/grade.service';
 
 @Injectable()
-export class RankService {}
+export class RankService {
+    constructor(
+        private githubService: GithubService,
+        private algorithmService: AlgorithmService,
+        private gradeService: GradeService,
+    ) {}
+
+    async findStat(userId: string) {
+        const github = await this.githubService.findGithub(userId);
+        const algorithm = await this.algorithmService.findAlgorithm(userId);
+        const grade = await this.gradeService.findGrade(userId);
+
+        return {
+            githubPoint: github ? github.point : null,
+            algorithmPoint: algorithm ? algorithm.point : null,
+            grade: grade ? grade.grade : null,
+        };
+    }
+}

--- a/src/rank/stat-find.dto.ts
+++ b/src/rank/stat-find.dto.ts
@@ -1,0 +1,5 @@
+export class StatFindDto {
+    githubPoint: number;
+    algorithmPoint: number;
+    grade: number;
+}


### PR DESCRIPTION
## 이슈
- #051

## 체크리스트
- [x] stat 조회 구현
- [x] B 구현

## 고민한 내용
### stat 조회 구조
- stat을 조회 하려면 github, algorithm, grade 의 서비스를 모두 사용해야한다.
- rank 조회 하는 모듈도 3가지 서비스를 모두 사용 함으로 같은 모듈과 서비스에 stat 도 포함 시켰다.
- 만들고 나니까 깔끔 해보이지는 않는다.

### typeORM synchronize 옵션
- 서버에서도 싱크를 임시로 맞추기 위해 true로 변경했습니다.