### PR TITLE
[#055] 회원가입해야하는 경우를 알려주는 표시 추가

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -66,21 +66,45 @@ describe('AuthService', () => {
         const user = new User();
         user.userId = 'user';
         user.providerId = providerId;
+        user.nickname = 'qwe';
+        user.major = 'qwe';
+        user.name = 'qwe';
+        user.studentId = 123;
         it('should login', async function () {
             mockUserService.findUserByProviderId.mockResolvedValue(user);
 
-            await service.logInOrSignUp(providerId);
+            const result = await service.logInOrSignUp(providerId);
 
             expect(mockUserService.createUser).not.toHaveBeenCalled();
+            expect(result.isMember).toEqual(true);
         });
 
-        it('should signup', async function () {
+        it('should signup if user does not exist', async function () {
             mockUserService.findUserByProviderId.mockResolvedValue(null);
             mockUserService.createUser.mockResolvedValue(user);
 
-            await service.logInOrSignUp(providerId);
+            const result = await service.logInOrSignUp(providerId);
 
             expect(mockUserService.createUser).toHaveBeenCalled();
+            expect(result.isMember).toEqual(false);
+        });
+
+        it('should signup if user`s data is not perfect', async function () {
+            mockUserService.createUser = jest.fn();
+            const user = new User();
+            user.userId = 'user';
+            user.providerId = providerId;
+            user.major = 'qwe';
+            user.name = 'qwe';
+            user.studentId = 123;
+            mockUserService.findUserByProviderId.mockResolvedValue(user);
+
+            mockUserService.createUser.mockResolvedValue(user);
+
+            const result = await service.logInOrSignUp(providerId);
+
+            expect(mockUserService.createUser).not.toHaveBeenCalled();
+            expect(result.isMember).toEqual(false);
         });
     });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,12 +19,14 @@ export class AuthService {
 
     async logInOrSignUp(providerId: string) {
         let user = await this.userService.findUserByProviderId(providerId);
+        let isMember = true;
         if (!user) {
             user = await this.userService.createUser(providerId);
+            isMember = false;
         }
         const accessToken = this.generateAccessToken(user);
         const refreshToken = this.generateRefreshToken(user);
-        return { accessToken, refreshToken };
+        return { accessToken, refreshToken, isMember };
     }
 
     generateAccessToken(user: User): string {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Post } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AppleLoginDto } from './appleLogin.dto';
 import * as jwt from 'jsonwebtoken';
 import * as jwksClient from 'jwks-rsa';
@@ -19,10 +19,9 @@ export class AuthService {
 
     async logInOrSignUp(providerId: string) {
         let user = await this.userService.findUserByProviderId(providerId);
-        let isMember = true;
+        const isMember = this.isMember(user);
         if (!user) {
             user = await this.userService.createUser(providerId);
-            isMember = false;
         }
         const accessToken = this.generateAccessToken(user);
         const refreshToken = this.generateRefreshToken(user);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -29,6 +29,16 @@ export class AuthService {
         return { accessToken, refreshToken, isMember };
     }
 
+    isMember(user: User) {
+        return !(
+            !user ||
+            !user.name ||
+            !user.studentId ||
+            !user.major ||
+            !user.nickname
+        );
+    }
+
     generateAccessToken(user: User): string {
         return this.jwtService.sign({
             userId: user.userId,


### PR DESCRIPTION
## 이슈
- #55

## 체크리스트
- [x] 로그인 응답으로 회원가입 여부 응답


## 고민한 내용
### 회원가입 여부 표시
- user가 존재해서 로그인이 된 경우와 존재 하지 않아서 회원가입이 필요한 경우를 구분하는 필드를 추가 했다.
```
{ 
accessToken, 
refreshToken, 
isMember 
}
```
- 회원가입을 진행하다가 앱을 종료한 경우도 고려 해야하기 때문에 유저 정보가 전부 입력되지 않는 경우 회원가입이 되지 않은 것으로 판단 했다
