### PR TITLE
[#075] 로그인 성공시 userId 같이 반환

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -27,13 +27,14 @@ export class AuthService {
     async logInOrSignUp(providerId: string) {
         let user = await this.userService.findUserByProviderId(providerId);
         const isMember = this.isMember(user);
+        const userId = user.id;
         if (!user) {
             user = await this.userService.createUser(providerId);
             await this.totalService.createTotalPoint(user.userId);
         }
         const accessToken = this.generateAccessToken(user.userId);
         const refreshToken = this.generateRefreshToken(user.userId);
-        return { accessToken, refreshToken, isMember };
+        return { accessToken, refreshToken, isMember, userId };
     }
 
     isMember(user: User) {
@@ -147,7 +148,6 @@ export class AuthService {
             return { isAuthorized: isSejongJson.result.is_auth };
         }
     }
-
 
     public async checkNicknameDuplicate(nickname: string) {
         const isExist = await this.userService.checkNicknameDuplicate(nickname);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -27,14 +27,13 @@ export class AuthService {
     async logInOrSignUp(providerId: string) {
         let user = await this.userService.findUserByProviderId(providerId);
         const isMember = this.isMember(user);
-        const userId = user.id;
         if (!user) {
             user = await this.userService.createUser(providerId);
             await this.totalService.createTotalPoint(user.userId);
         }
         const accessToken = this.generateAccessToken(user.userId);
         const refreshToken = this.generateRefreshToken(user.userId);
-        return { accessToken, refreshToken, isMember, userId };
+        return { accessToken, refreshToken, isMember, userId: user.studentId };
     }
 
     isMember(user: User) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -33,7 +33,7 @@ export class AuthService {
         }
         const accessToken = this.generateAccessToken(user.userId);
         const refreshToken = this.generateRefreshToken(user.userId);
-        return { accessToken, refreshToken, isMember, userId: user.studentId };
+        return { accessToken, refreshToken, isMember, userId: user.userId };
     }
 
     isMember(user: User) {


### PR DESCRIPTION
## 이슈
- #075

## 체크리스트
- [x] 로그인 성공시 userId 같이 반환
- [x] B 구현

## 고민한 내용
- 클라이언트 쪽의 요청으로 로그인 성공시 body에 access_token, refresh_token 외에 userId도 전달하도록 했다
