### PR TITLE
[#065] 알고리즘 랭크를 확인 할 수 있는 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { StatModule } from './stat/stat.module';
+import { RankModule } from './rank/rank.module';
 import * as process from 'process';
 
 @Module({
@@ -21,6 +22,7 @@ import * as process from 'process';
         AuthModule,
         UserModule,
         StatModule,
+        RankModule,
     ],
     controllers: [AppController],
     providers: [AppService],

--- a/src/rank/rank-list-option.dto.ts
+++ b/src/rank/rank-list-option.dto.ts
@@ -1,0 +1,17 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class RankListOptionDto {
+    @IsString()
+    @IsOptional()
+    major: string;
+
+    @IsNumber()
+    @IsOptional()
+    class: number;
+
+    @IsOptional()
+    cursorPoint: number;
+
+    @IsOptional()
+    cursorUserId: string;
+}

--- a/src/rank/rank-list-option.dto.ts
+++ b/src/rank/rank-list-option.dto.ts
@@ -1,0 +1,11 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class RankListOptionDto {
+    @IsString()
+    major: string;
+
+    @IsNumber()
+    class: number;
+
+    cursor: string;
+}

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
+import { RankListOptionDto } from './rank-list-option.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/rank')
+export class RankController {
+    @Get('algorithm')
+    findAll(@Query() options: RankListOptionDto) {
+        return {};
+    }
+}

--- a/src/rank/rank.controller.ts
+++ b/src/rank/rank.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { RankListOptionDto } from './rank-list-option.dto';
+import { AlgorithmService } from '../stat/service/algorithm.service';
 
 @UseGuards(JwtAuthGuard)
 @Controller('api/rank')
 export class RankController {
+    constructor(private algorithmService: AlgorithmService) {}
     @Get('algorithm')
-    findAll(@Query() options: RankListOptionDto) {
-        return {};
+    async findAlgorithmRank(@Query() options: RankListOptionDto) {
+        return await this.algorithmService.getAlgorithms(options);
     }
 }

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RankController } from './rank.controller';
 import { RankService } from './rank.service';
+import { StatModule } from '../stat/stat.module';
 
 @Module({
+    imports: [StatModule],
     controllers: [RankController],
     providers: [RankService],
 })

--- a/src/rank/rank.module.ts
+++ b/src/rank/rank.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RankController } from './rank.controller';
+import { RankService } from './rank.service';
+
+@Module({
+    controllers: [RankController],
+    providers: [RankService],
+})
+export class RankModule {}

--- a/src/rank/rank.service.spec.ts
+++ b/src/rank/rank.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RankService } from './rank.service';
+
+describe('RankService', () => {
+  let service: RankService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RankService],
+    }).compile();
+
+    service = module.get<RankService>(RankService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/rank/rank.service.ts
+++ b/src/rank/rank.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RankService {}

--- a/src/stat/repository/algorithm.repository.ts
+++ b/src/stat/repository/algorithm.repository.ts
@@ -54,7 +54,7 @@ export class AlgorithmRepository extends BaseRepository {
 
     createClassificationOption(options: RankListOptionDto) {
         if (options.major != null) {
-            return `u.major = ${options.major}`;
+            return `u.major like '${options.major}'`;
         } else {
             return `u.id > 0`;
         }

--- a/src/stat/repository/algorithm.repository.ts
+++ b/src/stat/repository/algorithm.repository.ts
@@ -3,6 +3,8 @@ import { Inject, Injectable, Scope } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
 import { Algorithm } from '../../Entity/algorithm';
+import { RankListOptionDto } from '../../rank/rank-list-option.dto';
+import { User } from '../../Entity/user';
 
 @Injectable({ scope: Scope.REQUEST })
 export class AlgorithmRepository extends BaseRepository {
@@ -18,6 +20,32 @@ export class AlgorithmRepository extends BaseRepository {
 
     async findOneById(userId: string) {
         return await this.repository.findOneBy({ userId: userId });
+    }
+
+    async findAlgorithmWithRank(options: RankListOptionDto) {
+        const queryBuilder = this.repository
+            .createQueryBuilder()
+            .select(['b.rank', 'b.user_id', 'b.point'])
+            .distinct(true)
+            .from((sub) => {
+                return sub
+                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
+                    .addSelect('a.user_id', 'user_id')
+                    .addSelect('a.point', 'point')
+                    .from(Algorithm, 'a');
+            }, 'b')
+            .innerJoin(User, 'u', 'b.user_id = u.user_id')
+            .addSelect('u.nickname', 'nickname')
+            .where('b.point < :point', { point: options.cursorPoint })
+            .orWhere('b.point = :point AND b.user_id > :userId', {
+                point: options.cursorPoint,
+                userId: options.cursorUserId,
+            })
+            .orderBy('point', 'DESC')
+            .addOrderBy('user_id')
+            .limit(3);
+
+        return await queryBuilder.getRawMany();
     }
 
     async update(userId: string, algorithm: Algorithm) {

--- a/src/stat/service/algorithm.service.ts
+++ b/src/stat/service/algorithm.service.ts
@@ -8,6 +8,7 @@ import axios from 'axios';
 import { AlgorithmRepository } from '../repository/algorithm.repository';
 import { Algorithm } from '../../Entity/algorithm';
 import { NotFoundError } from 'rxjs';
+import { RankListOptionDto } from '../../rank/rank-list-option.dto';
 
 const URL = 'https://solved.ac/api/v3/user/show?handle=';
 
@@ -23,6 +24,17 @@ export class AlgorithmService {
     async findAlgorithm(userId: string) {
         return await this.algorithmRepository.findOneById(userId);
     }
+
+    async getAlgorithms(options: RankListOptionDto) {
+        if (
+            (options.cursorPoint && !options.cursorUserId) ||
+            (!options.cursorPoint && options.cursorUserId)
+        ) {
+            throw new BadRequestException('Cursor Element Must Be Two');
+        }
+        return await this.algorithmRepository.findAlgorithmWithRank(options);
+    }
+
     async createAlgorithm(userId: string, bojId: string) {
         const bojInfo = await this.getBOJInfo(bojId);
         const isExist = await this.algorithmRepository.findOneById(userId);

--- a/src/stat/stat.module.ts
+++ b/src/stat/stat.module.ts
@@ -21,6 +21,6 @@ import { TotalRepository } from './repository/total.repository';
         TotalService,
         TotalRepository,
     ],
-    exports: [TotalService],
+    exports: [TotalService, GithubService, AlgorithmService, GradeService],
 })
 export class StatModule {}


### PR DESCRIPTION
## 이슈
- #065

## 체크리스트
- [x] 알고리즘 랭크를 찾는 기능 구현
- [x] 커서, 학과 등의 필터 적용 

## 고민한 내용
### 페이지 네이션 문제

- 커서 기준 잡기가 쉽지 않다. point 를 기준으로 정렬해서 내려준다. 하지만 point 가 동점자가 있을 수도 있기 때문에 커서로 선정하기는 문제가 있다. 동점자에 대해서 페이지네이션이 잘 적용되지 않는다.
- 때문에 point 와 user_id를 같이 커서로 선정했다. 정렬은 point 기준으로 되고 동점자인 경우 userId 사전 순으로 된다.

### 랭크 찾기 문제

- 쿼리를 해오며 해당 행의 등수를 찾아와야한다. limit 를 주었기 때문에 그냥 쿼리하면 지금 찾은 데이터에서 1등 부터 매겨서 준다. 이렇게 되면 전체 등수를 알 수 없는 문제가 있다.
- 해결하기 위해 서브 쿼리를 사용했다. 먼저 모든 데이터에 등수를 매기고 그 데이터에서 현재 찾을 데이터를 가져오면 해결되었다.
    - 아마 서브 쿼리가 사용되었기 때문에 속도가 느려지는 단점이 있지 않을까 하는 생각이 든다.

### option
- option 존재 여부에 따라 쿼리를 다르게 구성해야 하기 때문에 쿼리 옵션을 생성하는 메서드를 분리 하였다.
