### PR TITLE
[#087] 모든 역량 랭크를 조회하는 기능 구현

### DIFF
--- a/src/Entity/user.ts
+++ b/src/Entity/user.ts
@@ -1,7 +1,6 @@
 import {
     Column,
     CreateDateColumn,
-    DeleteDateColumn,
     Entity,
     OneToOne,
     PrimaryGeneratedColumn,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,8 +11,6 @@ import * as process from 'process';
 import { HttpLoggerInterceptor } from './utils/httpLoggerInterceptor';
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { HttpExceptionFilter } from './utils/httpExceptionFilter';
-import { WinstonModule } from 'nest-winston';
-import { transports } from 'winston';
 
 @Module({
     imports: [

--- a/src/stat/dto/rank-list-option.dto.ts
+++ b/src/stat/dto/rank-list-option.dto.ts
@@ -21,7 +21,7 @@ export class RankListDto {
     rank: number;
 
     @ApiProperty()
-    user_id: string;
+    userId: string;
 
     @ApiProperty()
     point: number;

--- a/src/stat/dto/stat-find.dto.ts
+++ b/src/stat/dto/stat-find.dto.ts
@@ -9,4 +9,7 @@ export class StatFindDto {
 
     @ApiProperty()
     grade: number;
+
+    @ApiProperty()
+    totalPoint: number;
 }

--- a/src/stat/rank.controller.ts
+++ b/src/stat/rank.controller.ts
@@ -77,6 +77,56 @@ export class RankController {
         return await this.githubService.getGithubRank(options);
     }
 
+    @Get('grade')
+    @ApiTags('rank')
+    @ApiOperation({
+        summary: '학점 전체 랭킹 API',
+        description:
+            '학점 역량의 랭킹리스트를 반환한다. 페이지네이션이 가능하고 학과 별로 필터링 가능하다. (학번 필터링은 아직 미구현) 커서 사용시 cursorPoint, cursorUserId 두개를 동시에 넣어야한다. 각각 마지막으로 받은 유저의 점수와 유저 아이디이다.',
+    })
+    @ApiBearerAuth('accessToken')
+    @ApiOkResponse({
+        description: '학점 랭킹 반환',
+        type: [RankListDto],
+    })
+    @ApiUnauthorizedResponse({
+        description: 'jwt 관련 문제 (인증 시간이 만료됨, jwt를 보내지 않음)',
+    })
+    @ApiForbiddenResponse({
+        description: '허용되지 않은 자원에 접근한 경우. 즉, 권한이 없는 경우',
+    })
+    @ApiInternalServerErrorResponse({
+        description: '서버 오류',
+    })
+    async findGradeRank(@Query() options: RankListOptionDto) {
+        return await this.gradeService.getGradeRank(options);
+    }
+
+    @Get('total')
+    @ApiTags('rank')
+    @ApiOperation({
+        summary: '종 전체 랭킹 API',
+        description:
+            '학점 역량의 랭킹리스트를 반환한다. 페이지네이션이 가능하고 학과 별로 필터링 가능하다. (학번 필터링은 아직 미구현) 커서 사용시 cursorPoint, cursorUserId 두개를 동시에 넣어야한다. 각각 마지막으로 받은 유저의 점수와 유저 아이디이다.',
+    })
+    @ApiBearerAuth('accessToken')
+    @ApiOkResponse({
+        description: '종합 랭킹 반환',
+        type: [RankListDto],
+    })
+    @ApiUnauthorizedResponse({
+        description: 'jwt 관련 문제 (인증 시간이 만료됨, jwt를 보내지 않음)',
+    })
+    @ApiForbiddenResponse({
+        description: '허용되지 않은 자원에 접근한 경우. 즉, 권한이 없는 경우',
+    })
+    @ApiInternalServerErrorResponse({
+        description: '서버 오류',
+    })
+    async findTotalRank(@Query() options: RankListOptionDto) {
+        return await this.totalService.getTotalRank(options);
+    }
+
     @Get('/users/:id')
     @ApiTags('rank')
     @ApiOperation({

--- a/src/stat/rank.controller.ts
+++ b/src/stat/rank.controller.ts
@@ -127,7 +127,6 @@ export class RankController {
         return await this.totalService.getTotalRank(options);
     }
 
-    @Get('/users/:id')
     @ApiTags('rank')
     @ApiOperation({
         summary: '유저의 각 부문 별 랭킹 API',
@@ -148,10 +147,14 @@ export class RankController {
     @ApiInternalServerErrorResponse({
         description: '서버 오류',
     })
-    async findUsersRank(@Param('id') userId, @Query() options: PointFindDto) {
+    @Get('/users/:id')
+    async findUsersRank(
+        @Param('id') userId: string,
+        @Query() options: PointFindDto,
+    ) {
         const user = await this.userService.findUserByUserId(userId);
 
-        if (options && user.major !== options.major) {
+        if (options.major && user.major !== options.major) {
             return new RankFindDto(null, null, null, null);
         } else {
             const algorithmRank =

--- a/src/stat/rank.controller.ts
+++ b/src/stat/rank.controller.ts
@@ -86,7 +86,7 @@ export class RankController {
     })
     @ApiBearerAuth('accessToken')
     @ApiOkResponse({
-        description: '학점 랭킹 반환',
+        description: '깃허브 랭킹 반환',
         type: [RankListDto],
     })
     @ApiUnauthorizedResponse({
@@ -105,7 +105,7 @@ export class RankController {
     @Get('total')
     @ApiTags('rank')
     @ApiOperation({
-        summary: '종 전체 랭킹 API',
+        summary: '종합 전체 랭킹 API',
         description:
             '학점 역량의 랭킹리스트를 반환한다. 페이지네이션이 가능하고 학과 별로 필터링 가능하다. (학번 필터링은 아직 미구현) 커서 사용시 cursorPoint, cursorUserId 두개를 동시에 넣어야한다. 각각 마지막으로 받은 유저의 점수와 유저 아이디이다.',
     })

--- a/src/stat/rank.controller.ts
+++ b/src/stat/rank.controller.ts
@@ -52,6 +52,31 @@ export class RankController {
         return await this.algorithmService.getAlgorithms(options);
     }
 
+    @Get('github')
+    @ApiTags('rank')
+    @ApiOperation({
+        summary: '깃허브 전체 랭킹 API',
+        description:
+            '깃허브 역량의 랭킹리스트를 반환한다. 페이지네이션이 가능하고 학과 별로 필터링 가능하다. (학번 필터링은 아직 미구현) 커서 사용시 cursorPoint, cursorUserId 두개를 동시에 넣어야한다. 각각 마지막으로 받은 유저의 점수와 유저 아이디이다.',
+    })
+    @ApiBearerAuth('accessToken')
+    @ApiOkResponse({
+        description: '깃허브 랭킹 반환',
+        type: [RankListDto],
+    })
+    @ApiUnauthorizedResponse({
+        description: 'jwt 관련 문제 (인증 시간이 만료됨, jwt를 보내지 않음)',
+    })
+    @ApiForbiddenResponse({
+        description: '허용되지 않은 자원에 접근한 경우. 즉, 권한이 없는 경우',
+    })
+    @ApiInternalServerErrorResponse({
+        description: '서버 오류',
+    })
+    async findGithubRank(@Query() options: RankListOptionDto) {
+        return await this.githubService.getGithubRank(options);
+    }
+
     @Get('/users/:id')
     @ApiTags('rank')
     @ApiOperation({

--- a/src/stat/repository/algorithm.repository.ts
+++ b/src/stat/repository/algorithm.repository.ts
@@ -38,7 +38,7 @@ export class AlgorithmRepository extends StatRepository {
                     .addSelect('u.major', 'major')
                     .where(this.createClassificationOption(options));
             }, 'b')
-            .where(`b.user_id = ${userId}`);
+            .where(`b.user_id = '${userId}'`);
 
         return await queryBuilder.getRawOne();
     }

--- a/src/stat/repository/algorithm.repository.ts
+++ b/src/stat/repository/algorithm.repository.ts
@@ -5,7 +5,6 @@ import { REQUEST } from '@nestjs/core';
 import { Algorithm } from '../../Entity/algorithm';
 import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { User } from '../../Entity/user';
-import { RankController } from '../rank.controller';
 import { PointFindDto } from '../dto/rank-find.dto';
 
 @Injectable({ scope: Scope.REQUEST })

--- a/src/stat/repository/github.repository.ts
+++ b/src/stat/repository/github.repository.ts
@@ -2,8 +2,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Github } from '../../Entity/github';
 import { DataSource } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
-import { User } from '../../Entity/user';
-import { PointFindDto } from '../dto/rank-find.dto';
 import { StatRepository } from '../../utils/stat.repository';
 
 @Injectable()
@@ -37,27 +35,5 @@ export class GithubRepository extends StatRepository {
 
     public async findAll() {
         return await this.repository.find();
-    }
-
-    public async findIndividualGithubRank(
-        userId: string,
-        options: PointFindDto,
-    ) {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY g.point DESC)', 'rank')
-                    .addSelect('g.user_id', 'user_id')
-                    .addSelect('g.point', 'point')
-                    .from(Github, 'g')
-                    .innerJoin(User, 'u', 'g.user_id = u.user_id')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(`b.user_id = ${userId}`);
-
-        return await queryBuilder.getRawOne();
     }
 }

--- a/src/stat/repository/github.repository.ts
+++ b/src/stat/repository/github.repository.ts
@@ -1,10 +1,9 @@
 import { BaseRepository } from '../../utils/base.repository';
-import { Inject, Injectable, Scope } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Github } from '../../Entity/github';
 import { DataSource, Repository } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
 import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
-import { Algorithm } from '../../Entity/algorithm';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
 

--- a/src/stat/repository/github.repository.ts
+++ b/src/stat/repository/github.repository.ts
@@ -1,19 +1,15 @@
-import { BaseRepository } from '../../utils/base.repository';
 import { Inject, Injectable } from '@nestjs/common';
 import { Github } from '../../Entity/github';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
-import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
+import { StatRepository } from '../../utils/stat.repository';
 
 @Injectable()
-export class GithubRepository extends BaseRepository {
-    private repository: Repository<Github>;
-
+export class GithubRepository extends StatRepository {
     constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
-        super(dataSource, req);
-        this.repository = this.getRepository(Github);
+        super(dataSource, req, Github);
     }
 
     public async save(github: Github) {
@@ -63,45 +59,5 @@ export class GithubRepository extends BaseRepository {
             .where(`b.user_id = ${userId}`);
 
         return await queryBuilder.getRawOne();
-    }
-
-    createClassificationOption(options: PointFindDto) {
-        if (options.major != null) {
-            return `u.major like '${options.major}'`;
-        } else {
-            return `u.id > 0`;
-        }
-    }
-
-    async findGithubWithRank(
-        options: RankListOptionDto,
-    ): Promise<[RankListDto]> {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
-                    .addSelect('a.user_id', 'user_id')
-                    .addSelect('a.point', 'point')
-                    .addSelect('u.nickname', 'nickname')
-                    .from(Github, 'a')
-                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(this.createCursorOption(options))
-            .orderBy('point', 'DESC')
-            .addOrderBy('user_id')
-            .limit(3);
-        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
-    }
-
-    createCursorOption(options: RankListOptionDto) {
-        if (!options.cursorPoint && !options.cursorUserId) {
-            return 'b.point > -1';
-        } else {
-            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
-        }
     }
 }

--- a/src/stat/repository/grade.repository.ts
+++ b/src/stat/repository/grade.repository.ts
@@ -4,7 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { Github } from '../../Entity/github';
 import { REQUEST } from '@nestjs/core';
 import { Grade } from '../../Entity/grade';
-import { RankListOptionDto } from '../dto/rank-list-option.dto';
+import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
 
@@ -59,6 +59,38 @@ export class GradeRepository extends BaseRepository {
             .where(`b.user_id = ${userId}`);
 
         return await queryBuilder.getRawOne();
+    }
+
+    async findGradeWithRank(
+        options: RankListOptionDto,
+    ): Promise<[RankListDto]> {
+        const queryBuilder = this.repository
+            .createQueryBuilder()
+            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
+            .distinct(true)
+            .from((sub) => {
+                return sub
+                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
+                    .addSelect('a.user_id', 'user_id')
+                    .addSelect('a.point', 'point')
+                    .addSelect('u.nickname', 'nickname')
+                    .from(Grade, 'a')
+                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
+                    .where(this.createClassificationOption(options));
+            }, 'b')
+            .where(this.createCursorOption(options))
+            .orderBy('point', 'DESC')
+            .addOrderBy('user_id')
+            .limit(3);
+        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
+    }
+
+    createCursorOption(options: RankListOptionDto) {
+        if (!options.cursorPoint && !options.cursorUserId) {
+            return 'b.point > -1';
+        } else {
+            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
+        }
     }
 
     createClassificationOption(options: PointFindDto) {

--- a/src/stat/repository/grade.repository.ts
+++ b/src/stat/repository/grade.repository.ts
@@ -2,8 +2,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
 import { Grade } from '../../Entity/grade';
-import { User } from '../../Entity/user';
-import { PointFindDto } from '../dto/rank-find.dto';
 import { StatRepository } from '../../utils/stat.repository';
 
 @Injectable()
@@ -32,27 +30,5 @@ export class GradeRepository extends StatRepository {
 
     public async delete(id: string) {
         await this.repository.delete({ userId: id });
-    }
-
-    public async findIndividualGradeRank(
-        userId: string,
-        options: PointFindDto,
-    ) {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY g.point DESC)', 'rank')
-                    .addSelect('g.user_id', 'user_id')
-                    .addSelect('g.point', 'point')
-                    .from(Grade, 'g')
-                    .innerJoin(User, 'u', 'g.user_id = u.user_id')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(`b.user_id = ${userId}`);
-
-        return await queryBuilder.getRawOne();
     }
 }

--- a/src/stat/repository/grade.repository.ts
+++ b/src/stat/repository/grade.repository.ts
@@ -1,7 +1,6 @@
 import { BaseRepository } from '../../utils/base.repository';
 import { Inject, Injectable } from '@nestjs/common';
 import { DataSource, Repository } from 'typeorm';
-import { Github } from '../../Entity/github';
 import { REQUEST } from '@nestjs/core';
 import { Grade } from '../../Entity/grade';
 import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';

--- a/src/stat/repository/grade.repository.ts
+++ b/src/stat/repository/grade.repository.ts
@@ -1,19 +1,15 @@
-import { BaseRepository } from '../../utils/base.repository';
 import { Inject, Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
 import { Grade } from '../../Entity/grade';
-import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
+import { StatRepository } from '../../utils/stat.repository';
 
 @Injectable()
-export class GradeRepository extends BaseRepository {
-    private repository: Repository<Grade>;
-
+export class GradeRepository extends StatRepository {
     constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
-        super(dataSource, req);
-        this.repository = this.getRepository(Grade);
+        super(dataSource, req, Grade);
     }
 
     public async save(grade: Grade) {
@@ -58,45 +54,5 @@ export class GradeRepository extends BaseRepository {
             .where(`b.user_id = ${userId}`);
 
         return await queryBuilder.getRawOne();
-    }
-
-    async findGradeWithRank(
-        options: RankListOptionDto,
-    ): Promise<[RankListDto]> {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
-                    .addSelect('a.user_id', 'user_id')
-                    .addSelect('a.point', 'point')
-                    .addSelect('u.nickname', 'nickname')
-                    .from(Grade, 'a')
-                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(this.createCursorOption(options))
-            .orderBy('point', 'DESC')
-            .addOrderBy('user_id')
-            .limit(3);
-        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
-    }
-
-    createCursorOption(options: RankListOptionDto) {
-        if (!options.cursorPoint && !options.cursorUserId) {
-            return 'b.point > -1';
-        } else {
-            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
-        }
-    }
-
-    createClassificationOption(options: PointFindDto) {
-        if (options.major != null) {
-            return `u.major like '${options.major}'`;
-        } else {
-            return `u.id > 0`;
-        }
     }
 }

--- a/src/stat/repository/total.repository.ts
+++ b/src/stat/repository/total.repository.ts
@@ -2,9 +2,6 @@ import { DataSource } from 'typeorm';
 import { Inject } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { TotalPoint } from '../../Entity/totalPoint';
-import { Algorithm } from '../../Entity/algorithm';
-import { User } from '../../Entity/user';
-import { PointFindDto } from '../dto/rank-find.dto';
 import { StatRepository } from '../../utils/stat.repository';
 
 export class TotalRepository extends StatRepository {
@@ -22,28 +19,5 @@ export class TotalRepository extends StatRepository {
 
     async save(total: TotalPoint) {
         return await this.repository.save(total);
-    }
-
-    public async findIndividualAlgorithmRank(
-        userId: string,
-        options: PointFindDto,
-    ) {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id', 'b.major'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
-                    .addSelect('a.user_id', 'user_id')
-                    .addSelect('a.point', 'point')
-                    .from(Algorithm, 'a')
-                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
-                    .addSelect('u.major', 'major')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(`b.user_id = ${userId}`);
-
-        return await queryBuilder.getRawOne();
     }
 }

--- a/src/stat/repository/total.repository.ts
+++ b/src/stat/repository/total.repository.ts
@@ -1,19 +1,15 @@
-import { BaseRepository } from '../../utils/base.repository';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { Inject } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { TotalPoint } from '../../Entity/totalPoint';
-import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { Algorithm } from '../../Entity/algorithm';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
+import { StatRepository } from '../../utils/stat.repository';
 
-export class TotalRepository extends BaseRepository {
-    private repository: Repository<TotalPoint>;
-
+export class TotalRepository extends StatRepository {
     constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
-        super(dataSource, req);
-        this.repository = this.getRepository(TotalPoint);
+        super(dataSource, req, TotalPoint);
     }
 
     async findOneById(userId: string) {
@@ -49,45 +45,5 @@ export class TotalRepository extends BaseRepository {
             .where(`b.user_id = ${userId}`);
 
         return await queryBuilder.getRawOne();
-    }
-
-    createClassificationOption(options: PointFindDto) {
-        if (options.major != null) {
-            return `u.major like '${options.major}'`;
-        } else {
-            return `u.id > 0`;
-        }
-    }
-
-    async findTotalWithRank(
-        options: RankListOptionDto,
-    ): Promise<[RankListDto]> {
-        const queryBuilder = this.repository
-            .createQueryBuilder()
-            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
-            .distinct(true)
-            .from((sub) => {
-                return sub
-                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
-                    .addSelect('a.user_id', 'user_id')
-                    .addSelect('a.point', 'point')
-                    .addSelect('u.nickname', 'nickname')
-                    .from(TotalPoint, 'a')
-                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
-                    .where(this.createClassificationOption(options));
-            }, 'b')
-            .where(this.createCursorOption(options))
-            .orderBy('point', 'DESC')
-            .addOrderBy('user_id')
-            .limit(3);
-        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
-    }
-
-    createCursorOption(options: RankListOptionDto) {
-        if (!options.cursorPoint && !options.cursorUserId) {
-            return 'b.point > -1';
-        } else {
-            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
-        }
     }
 }

--- a/src/stat/repository/total.repository.ts
+++ b/src/stat/repository/total.repository.ts
@@ -1,6 +1,5 @@
 import { BaseRepository } from '../../utils/base.repository';
 import { DataSource, Repository } from 'typeorm';
-import { Grade } from '../../Entity/grade';
 import { Inject } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { TotalPoint } from '../../Entity/totalPoint';
@@ -8,7 +7,6 @@ import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { Algorithm } from '../../Entity/algorithm';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
-import { Github } from '../../Entity/github';
 
 export class TotalRepository extends BaseRepository {
     private repository: Repository<TotalPoint>;

--- a/src/stat/repository/total.repository.ts
+++ b/src/stat/repository/total.repository.ts
@@ -4,10 +4,11 @@ import { Grade } from '../../Entity/grade';
 import { Inject } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { TotalPoint } from '../../Entity/totalPoint';
-import { RankListOptionDto } from '../dto/rank-list-option.dto';
+import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { Algorithm } from '../../Entity/algorithm';
 import { User } from '../../Entity/user';
 import { PointFindDto } from '../dto/rank-find.dto';
+import { Github } from '../../Entity/github';
 
 export class TotalRepository extends BaseRepository {
     private repository: Repository<TotalPoint>;
@@ -57,6 +58,38 @@ export class TotalRepository extends BaseRepository {
             return `u.major like '${options.major}'`;
         } else {
             return `u.id > 0`;
+        }
+    }
+
+    async findTotalWithRank(
+        options: RankListOptionDto,
+    ): Promise<[RankListDto]> {
+        const queryBuilder = this.repository
+            .createQueryBuilder()
+            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
+            .distinct(true)
+            .from((sub) => {
+                return sub
+                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
+                    .addSelect('a.user_id', 'user_id')
+                    .addSelect('a.point', 'point')
+                    .addSelect('u.nickname', 'nickname')
+                    .from(TotalPoint, 'a')
+                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
+                    .where(this.createClassificationOption(options));
+            }, 'b')
+            .where(this.createCursorOption(options))
+            .orderBy('point', 'DESC')
+            .addOrderBy('user_id')
+            .limit(3);
+        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
+    }
+
+    createCursorOption(options: RankListOptionDto) {
+        if (!options.cursorPoint && !options.cursorUserId) {
+            return 'b.point > -1';
+        } else {
+            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
         }
     }
 }

--- a/src/stat/service/algorithm.service.spec.ts
+++ b/src/stat/service/algorithm.service.spec.ts
@@ -3,12 +3,14 @@ import { AlgorithmService } from './algorithm.service';
 import axios from 'axios';
 import { AlgorithmRepository } from '../repository/algorithm.repository';
 import { Algorithm } from '../../Entity/algorithm';
+import { RankListOptionDto } from '../dto/rank-list-option.dto';
 
 const mockAlgorithmRepository = {
     save: jest.fn(),
     findOneById: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    findAlgorithmWithRank: jest.fn(),
 };
 
 jest.mock('axios');
@@ -219,6 +221,27 @@ describe('AlgorithmService', () => {
             algorithmRepository.findOneById.mockResolvedValue(null);
             await expect(service.removeAlgorithm(userId)).rejects.toThrow(
                 'algorithm not found',
+            );
+        });
+    });
+
+    describe('getAlgorithms', function () {
+        it('cursor 를 하나만 보내면 오류를 던진다.', function () {
+            const options1: RankListOptionDto = {
+                cursorUserId: null,
+                major: null,
+                cursorPoint: 12,
+            };
+            const options2: RankListOptionDto = {
+                cursorUserId: 'qwe',
+                major: null,
+                cursorPoint: null,
+            };
+            expect(service.getAlgorithms(options1)).rejects.toThrow(
+                'Cursor Element Must Be Two',
+            );
+            expect(service.getAlgorithms(options2)).rejects.toThrow(
+                'Cursor Element Must Be Two',
             );
         });
     });

--- a/src/stat/service/algorithm.service.ts
+++ b/src/stat/service/algorithm.service.ts
@@ -123,7 +123,7 @@ export class AlgorithmService {
         userId: string,
         options: PointFindDto,
     ) {
-        return await this.algorithmRepository.findIndividualAlgorithmRank(
+        return await this.algorithmRepository.findIndividualRank(
             userId,
             options,
         );

--- a/src/stat/service/algorithm.service.ts
+++ b/src/stat/service/algorithm.service.ts
@@ -34,7 +34,7 @@ export class AlgorithmService {
         ) {
             throw new BadRequestException('Cursor Element Must Be Two');
         }
-        return await this.algorithmRepository.findAlgorithmWithRank(options);
+        return await this.algorithmRepository.findWithRank(options);
     }
 
     async createAlgorithm(userId: string, bojId: string) {

--- a/src/stat/service/github.service.ts
+++ b/src/stat/service/github.service.ts
@@ -166,6 +166,6 @@ export class GithubService {
         ) {
             throw new BadRequestException('Cursor Element Must Be Two');
         }
-        return await this.githubRepository.findGithubWithRank(options);
+        return await this.githubRepository.findWithRank(options);
     }
 }

--- a/src/stat/service/github.service.ts
+++ b/src/stat/service/github.service.ts
@@ -134,10 +134,7 @@ export class GithubService {
         userId: string,
         options: PointFindDto,
     ) {
-        return await this.githubRepository.findIndividualGithubRank(
-            userId,
-            options,
-        );
+        return await this.githubRepository.findIndividualRank(userId, options);
     }
 
     // public async redirect(code: string) {

--- a/src/stat/service/github.service.ts
+++ b/src/stat/service/github.service.ts
@@ -160,4 +160,13 @@ export class GithubService {
     //     github.githubId = userResource.id;
     //     await this.githubRepository.save(github);
     // }
+    async getGithubRank(options: RankListOptionDto) {
+        if (
+            (options.cursorPoint && !options.cursorUserId) ||
+            (!options.cursorPoint && options.cursorUserId)
+        ) {
+            throw new BadRequestException('Cursor Element Must Be Two');
+        }
+        return await this.githubRepository.findGithubWithRank(options);
+    }
 }

--- a/src/stat/service/github.service.ts
+++ b/src/stat/service/github.service.ts
@@ -3,7 +3,6 @@ import {
     Injectable,
     InternalServerErrorException,
     Logger,
-    NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GithubRepository } from '../repository/github.repository';

--- a/src/stat/service/grade.service.ts
+++ b/src/stat/service/grade.service.ts
@@ -60,10 +60,7 @@ export class GradeService {
     }
 
     public async getIndividualGradeRank(userId: string, options: PointFindDto) {
-        return await this.gradeRepository.findIndividualGradeRank(
-            userId,
-            options,
-        );
+        return await this.gradeRepository.findIndividualRank(userId, options);
     }
 
     async getGradeRank(options: RankListOptionDto): Promise<[RankListDto]> {

--- a/src/stat/service/grade.service.ts
+++ b/src/stat/service/grade.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { GradeRepository } from '../repository/grade.repository';
 import { Grade } from '../../Entity/grade';
-import { RankListOptionDto } from '../dto/rank-list-option.dto';
+import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { PointFindDto } from '../dto/rank-find.dto';
 
 @Injectable()
@@ -64,5 +64,15 @@ export class GradeService {
             userId,
             options,
         );
+    }
+
+    async getGradeRank(options: RankListOptionDto): Promise<[RankListDto]> {
+        if (
+            (options.cursorPoint && !options.cursorUserId) ||
+            (!options.cursorPoint && options.cursorUserId)
+        ) {
+            throw new BadRequestException('Cursor Element Must Be Two');
+        }
+        return await this.gradeRepository.findGradeWithRank(options);
     }
 }

--- a/src/stat/service/grade.service.ts
+++ b/src/stat/service/grade.service.ts
@@ -73,6 +73,6 @@ export class GradeService {
         ) {
             throw new BadRequestException('Cursor Element Must Be Two');
         }
-        return await this.gradeRepository.findGradeWithRank(options);
+        return await this.gradeRepository.findWithRank(options);
     }
 }

--- a/src/stat/service/total.service.ts
+++ b/src/stat/service/total.service.ts
@@ -9,6 +9,7 @@ import { Grade } from '../../Entity/grade';
 import { Algorithm } from '../../Entity/algorithm';
 import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { PointFindDto } from '../dto/rank-find.dto';
+import { StatFindDto } from '../dto/stat-find.dto';
 
 @Injectable()
 export class TotalService {
@@ -19,15 +20,17 @@ export class TotalService {
         private gradeService: GradeService,
     ) {}
 
-    async findStat(userId: string) {
+    async findStat(userId: string): Promise<StatFindDto> {
         const github = await this.githubService.findGithub(userId);
         const algorithm = await this.algorithmService.findAlgorithm(userId);
         const grade = await this.gradeService.findGrade(userId);
+        const total = await this.totalRepository.findOneById(userId);
 
         return {
             githubPoint: github ? github.point : null,
             algorithmPoint: algorithm ? algorithm.point : null,
             grade: grade ? grade.grade : null,
+            totalPoint: grade ? total.point : null,
         };
     }
 

--- a/src/stat/service/total.service.ts
+++ b/src/stat/service/total.service.ts
@@ -68,9 +68,6 @@ export class TotalService {
     }
 
     public async getIndividualTotalRank(userId: string, options: PointFindDto) {
-        return await this.totalRepository.findIndividualAlgorithmRank(
-            userId,
-            options,
-        );
+        return await this.totalRepository.findIndividualRank(userId, options);
     }
 }

--- a/src/stat/service/total.service.ts
+++ b/src/stat/service/total.service.ts
@@ -38,7 +38,7 @@ export class TotalService {
         ) {
             throw new BadRequestException('Cursor Element Must Be Two');
         }
-        return await this.totalRepository.findTotalWithRank(options);
+        return await this.totalRepository.findWithRank(options);
     }
 
     async createTotalPoint(userId: string) {

--- a/src/stat/service/total.service.ts
+++ b/src/stat/service/total.service.ts
@@ -7,7 +7,7 @@ import { GradeService } from './grade.service';
 import { Github } from '../../Entity/github';
 import { Grade } from '../../Entity/grade';
 import { Algorithm } from '../../Entity/algorithm';
-import { RankListOptionDto } from '../dto/rank-list-option.dto';
+import { RankListDto, RankListOptionDto } from '../dto/rank-list-option.dto';
 import { PointFindDto } from '../dto/rank-find.dto';
 
 @Injectable()
@@ -30,6 +30,17 @@ export class TotalService {
             grade: grade ? grade.grade : null,
         };
     }
+
+    async getTotalRank(options: RankListOptionDto): Promise<[RankListDto]> {
+        if (
+            (options.cursorPoint && !options.cursorUserId) ||
+            (!options.cursorPoint && options.cursorUserId)
+        ) {
+            throw new BadRequestException('Cursor Element Must Be Two');
+        }
+        return await this.totalRepository.findTotalWithRank(options);
+    }
+
     async createTotalPoint(userId: string) {
         const isExist = await this.totalRepository.findOneById(userId);
 

--- a/src/utils/stat.repository.ts
+++ b/src/utils/stat.repository.ts
@@ -1,0 +1,59 @@
+import { BaseRepository } from './base.repository';
+import { DataSource, Repository } from 'typeorm';
+import { Algorithm } from '../Entity/algorithm';
+import { Inject } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import {
+    RankListDto,
+    RankListOptionDto,
+} from '../stat/dto/rank-list-option.dto';
+import { User } from '../Entity/user';
+import { PointFindDto } from '../stat/dto/rank-find.dto';
+
+export class StatRepository extends BaseRepository {
+    protected repository: Repository<any>;
+    private entity;
+    constructor(dataSource: DataSource, req: Request, entity) {
+        super(dataSource, req);
+        this.repository = this.getRepository(entity);
+        this.entity = entity;
+    }
+
+    async findWithRank(options: RankListOptionDto): Promise<[RankListDto]> {
+        const queryBuilder = this.repository
+            .createQueryBuilder()
+            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
+            .distinct(true)
+            .from((sub) => {
+                return sub
+                    .select('RANK() OVER (ORDER BY a.point DESC)', 'rank')
+                    .addSelect('a.user_id', 'user_id')
+                    .addSelect('a.point', 'point')
+                    .addSelect('u.nickname', 'nickname')
+                    .from(this.entity, 'a')
+                    .innerJoin(User, 'u', 'a.user_id = u.user_id')
+                    .where(this.createClassificationOption(options));
+            }, 'b')
+            .where(this.createCursorOption(options))
+            .orderBy('point', 'DESC')
+            .addOrderBy('user_id')
+            .limit(3);
+        return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
+    }
+
+    createCursorOption(options: RankListOptionDto) {
+        if (!options.cursorPoint && !options.cursorUserId) {
+            return 'b.point > -1';
+        } else {
+            return `b.point < ${options.cursorPoint} or b.point = ${options.cursorPoint} AND b.user_id > '${options.cursorUserId}'`;
+        }
+    }
+
+    createClassificationOption(options: PointFindDto) {
+        if (options.major != null) {
+            return `u.major like '${options.major}'`;
+        } else {
+            return `u.id > 0`;
+        }
+    }
+}

--- a/src/utils/stat.repository.ts
+++ b/src/utils/stat.repository.ts
@@ -19,7 +19,8 @@ export class StatRepository extends BaseRepository {
     async findWithRank(options: RankListOptionDto): Promise<[RankListDto]> {
         const queryBuilder = this.repository
             .createQueryBuilder()
-            .select(['b.rank', 'b.user_id', 'b.point', 'b.nickname'])
+            .select(['b.rank', 'b.point', 'b.nickname'])
+            .addSelect('b.user_id', 'userId')
             .distinct(true)
             .from((sub) => {
                 return sub
@@ -33,7 +34,7 @@ export class StatRepository extends BaseRepository {
             }, 'b')
             .where(this.createCursorOption(options))
             .orderBy('point', 'DESC')
-            .addOrderBy('user_id')
+            .addOrderBy('userId')
             .limit(3);
         return await (<Promise<[RankListDto]>>queryBuilder.getRawMany());
     }


### PR DESCRIPTION
## 이슈
- #087

## 체크리스트
- [x] 역량 랭크를 조회하는 기능 구현
- [x] totalPoint 도 stat 에서 같이 조회되도록 추가
- [x] user_id -> userId 수정
- [x] 공통 부분 리펙토링 

## 고민한 내용
### Repository 리펙토링
- stat 관련 repository에서 랭크 목록을 가져오는 메서드와 개인 랭킹을 가져오는 메서드들이 모든 repository에서 중복으로 나타났다.
- 중복된 코드를 줄이고자 `findWithRank`, `findIndividualRank` 코드를 구현한 StatRepository를 만들고 StatRepository를 상속해서 각 Repository에서 사용하게 수정하였다.
```
    protected repository: Repository<any>;
    private entity;
    constructor(dataSource: DataSource, req: Request, entity) {
        super(dataSource, req);
        this.repository = this.getRepository(entity);
        this.entity = entity;
    }
```
- 위와 같이 생성자에 엔티티를 넣어서 각 stat 별로 돌아갈 수 있도록 하였다