### PR TITLE
[#102] 모든 점수들을 소수점 2째자리에서 반올림 하도록 수정

### DIFF
--- a/src/Entity/algorithm.ts
+++ b/src/Entity/algorithm.ts
@@ -1,4 +1,6 @@
 import {
+    BeforeInsert,
+    BeforeUpdate,
     Column,
     CreateDateColumn,
     Entity,
@@ -35,7 +37,7 @@ export class Algorithm {
     @Column()
     solvedCount: number;
 
-    @Column('double')
+    @Column('decimal', { precision: 10, scale: 2 })
     score: number;
 
     @CreateDateColumn({
@@ -53,4 +55,10 @@ export class Algorithm {
     @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    roundAmount() {
+        this.score = Math.round(this.score * 100) / 100;
+    }
 }

--- a/src/Entity/github.ts
+++ b/src/Entity/github.ts
@@ -1,4 +1,6 @@
 import {
+    BeforeInsert,
+    BeforeUpdate,
     Column,
     CreateDateColumn,
     Entity,
@@ -23,7 +25,7 @@ export class Github {
     @Column()
     githubId: number;
 
-    @Column('double')
+    @Column('decimal', { precision: 10, scale: 2 })
     score: number;
 
     @Column()
@@ -44,4 +46,10 @@ export class Github {
     @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    roundAmount() {
+        this.score = Math.round(this.score * 100) / 100;
+    }
 }

--- a/src/Entity/grade.ts
+++ b/src/Entity/grade.ts
@@ -1,4 +1,6 @@
 import {
+    BeforeInsert,
+    BeforeUpdate,
     Column,
     CreateDateColumn,
     Entity,
@@ -23,7 +25,7 @@ export class Grade {
     @Column('double')
     grade: number;
 
-    @Column('double')
+    @Column('decimal', { precision: 10, scale: 2 })
     score: number;
 
     @CreateDateColumn({
@@ -41,4 +43,10 @@ export class Grade {
     @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })
     user: User;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    roundAmount() {
+        this.score = Math.round(this.score * 100) / 100;
+    }
 }

--- a/src/Entity/totalPoint.ts
+++ b/src/Entity/totalPoint.ts
@@ -1,4 +1,6 @@
 import {
+    BeforeInsert,
+    BeforeUpdate,
     Column,
     CreateDateColumn,
     Entity,
@@ -20,7 +22,7 @@ export class TotalPoint {
     })
     userId: string;
 
-    @Column('double')
+    @Column('decimal', { precision: 10, scale: 2 })
     score: number;
 
     @CreateDateColumn({
@@ -34,6 +36,12 @@ export class TotalPoint {
         nullable: true,
     })
     updateDate: Date;
+
+    @BeforeInsert()
+    @BeforeUpdate()
+    roundAmount() {
+        this.score = Math.round(this.score * 100) / 100;
+    }
 
     @OneToOne(() => User, (user) => user.userId, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id', referencedColumnName: 'userId' })


### PR DESCRIPTION
## 이슈
- #102

## 체크리스트
- [x] 모든 점수들을 소수점 2째자리에서 반올림 하도록 수정
## 고민한 내용
엔티티에서 업데이트와 삽입 연산시 자동으로 소수점 둘째짜리로 반올림하는 로직을 넣고 db 에도 제약조건을 걸었다.
