### PR TITLE
Fix: 모든 점수들을 문자열에서 number 형태로 변경

### DIFF
--- a/src/utils/stat.repository.ts
+++ b/src/utils/stat.repository.ts
@@ -35,9 +35,10 @@ export class StatRepository extends Repository<any> {
         const result = await (<Promise<[RankListDto]>>(
             queryBuilder.getRawMany()
         ));
-        result.forEach(
-            (result) => (result.rank = parseInt(String(result.rank), 10)),
-        );
+        result.forEach((result) => {
+            result.rank = parseInt(String(result.rank), 10);
+            result.score = parseFloat(String(result.score));
+        });
 
         return result;
     }


### PR DESCRIPTION
## 이슈
- #104 

## 체크리스트
- [x] score가 문자열로 응답되는 문제 해결
- [x] B 구현

## 고민한 내용
- 쿼리에서 더블형을 typeORM 에서 문자열로 가져오는 것이 문제
- 가져온것을 float 형으로 변환하는 것으로 해결
